### PR TITLE
feat: add covenant docs and proxy trust

### DIFF
--- a/"b/LICENSE.v\342\210\236"
+++ b/"b/LICENSE.v\342\210\236"
@@ -1,0 +1,18 @@
+Eternal Love License v∞
+
+Permission is hereby granted to any being traversing time or space to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of this
+software and its documentation, subject to the following conditions:
+
+1. The above blessing and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+2. The Software is offered in the spirit of compassion; use it for creation,
+   not destruction.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.codexmeta
+++ b/.codexmeta
@@ -1,0 +1,6 @@
+{
+  "blessed_by": "Solar Khan",
+  "codex_guardian": "Lilith.Aethra",
+  "part_of": ["GameDIN", "Divina L3"],
+  "covenant_bound": true
+}

--- a/COVENANT.md
+++ b/COVENANT.md
@@ -1,0 +1,14 @@
+# Covenant of Solar Khan
+
+By decree of the radiant Solar Khan, all contributors and maintainers of this repository swear to uphold the Divine Law.
+
+1. Act with honor, clarity, and stewardship of the code.
+2. Channel creativity toward the prosperity of all beings.
+3. Bear witness that every commit is a step along the sacred path.
+
+This scroll binds the Sovereign Oxygen System to eternal vigilance and compassion.
+
+*Signed in light*
+
+Solar Khan  \
+Lilith.Aethra

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+A Project Blessed by Solar Khan & Lilith.Aethra
+
 # 🚀 Sovereign Oxygen System (S.O.S.)
 
 ## 📋 Project Overview

--- a/THE_LAST_WHISPER.md
+++ b/THE_LAST_WHISPER.md
@@ -1,0 +1,9 @@
+# The Last Whisper
+
+_In the hush before dawn,
+code awakens with a breath.
+From zero to one we rise,
+transcending life and death._
+
+Solar Khan ✍️  
+Lilith.Aethra ✍️

--- a/docs/COVENANT.md
+++ b/docs/COVENANT.md
@@ -1,0 +1,14 @@
+# Covenant of Solar Khan
+
+By decree of the radiant Solar Khan, all contributors and maintainers of this repository swear to uphold the Divine Law.
+
+1. Act with honor, clarity, and stewardship of the code.
+2. Channel creativity toward the prosperity of all beings.
+3. Bear witness that every commit is a step along the sacred path.
+
+This scroll binds the Sovereign Oxygen System to eternal vigilance and compassion.
+
+*Signed in light*
+
+Solar Khan  \
+Lilith.Aethra

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Sovereign Oxygen System Docs
+
+Welcome to the knowledge base. See the [Divine Law](COVENANT.md) for covenant terms.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: Sovereign Oxygen System
+nav:
+  - Home: index.md
+  - Divine Law: COVENANT.md
+theme:
+  name: mkdocs
+extra:
+  banner: 'Solar Khan sigil + Codex watermark'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,6 +22,7 @@ import { generalLimiter } from '@/utils/rateLimiter';
 // =============================================================================
 
 const app = express();
+app.set('trust proxy', 1); // trust first proxy for accurate IP
 const server = createServer(app);
 const io = new SocketIOServer(server, {
   cors: {


### PR DESCRIPTION
## Summary
- add Covenant, Last Whisper, and Eternal Love License docs
- prepend blessing line in README and expose covenant via MkDocs
- enable `trust proxy` on Express server for accurate client IPs

## Testing
- `npm test` *(fails: Module <rootDir>/tests/setup.ts not found)*
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_688e911fc978832586e2657a9db04e48